### PR TITLE
Fix viewer issue where fps is not used correctly

### DIFF
--- a/example/position_retargeting/hand_robot_viewer.py
+++ b/example/position_retargeting/hand_robot_viewer.py
@@ -163,11 +163,11 @@ class RobotHandDatasetSAPIENViewer(HandDatasetSAPIENViewer):
                 rgb = (np.clip(rgb, 0, 1) * 255).astype(np.uint8)
                 writer.write(rgb[..., ::-1])
             else:
-                for k in range(start_frame):
+                for _ in range(step_per_frame):
                     self.viewer.render()
 
-        if self.headless:
-            writer.release()
-        else:
+        if not self.headless:
             self.viewer.paused = True
             self.viewer.render()
+        else:
+            writer.release()


### PR DESCRIPTION
The rendering is not working correctly for the hand_robot_viewer. Thus, following the position_retargeting example, the hand + robot example only shows the final state, not the movement of the objects + hands.

```
python visualize_hand_object.py --dexycb-dir=/juno/u/tylerlum/Downloads/dex_ycb_dataset/  --robots allegro shadow svh
```

This is because the wrong value is passed into the for loop, so I fixed it.

I also diffed hand_robot_view.py and hand_view.py, and then made 1 other change to make them more consistent

Current:
![current_behavior-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/40bfdf2d-afbc-4d92-9d5c-e987b23c5027)

New (after fix)
![new_behavior-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/3b8ab2ec-a52c-4ce0-a144-fc357ef6865b)
