### PR TITLE
fix: Mediapipe version limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install dex_retargeting
 To run the example, you may need additional dependencies for rendering and hand pose detection.
 
 ```shell
-git clone https://github.com/dexsuite/dex-retargeting
+git clone https://github.com/dexsuite/dex-retargeting --recursive
 cd dex-retargeting
 pip install -e ".[example]"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ example = [
     "tyro",
     "tqdm",
     "opencv-python",
-    "mediapipe",
+    "mediapipe<=0.10.21",
     "sapien==3.0.0b0",
     "loguru",
 ]


### PR DESCRIPTION
Mediapipe removed the framework bindings with `0.10.3x` so I added a version limit to the `toml` file. Also added `--recursive` flag to ensure assets are downloaded when cloning.

Lastly updated the commit hash of the assets submodule to include fix from https://github.com/dexsuite/dex-retargeting/issues/70.