### PR TITLE
Add PyTorch to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "numpy>=2.0.0",
     "pytransform3d>=3.5.0",
     "pin>=3.3.1",
+    "pytorch>=2.0.0",
     "nlopt>=2.8.0",
     "anytree>=2.12.0",
     "pyyaml>=6.0.0",


### PR DESCRIPTION
This PR adds PyTorch explicitly to the requirements. It was not listed in the pyproject.toml, but during the import the code checks for torch installation 

https://github.com/dexsuite/dex-retargeting/blob/3f56141bc8bd2760d5e452e382937269554ebb21/src/dex_retargeting/__init__.py#L3-L8